### PR TITLE
Import traceback for exception reporting.

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg_lifecycle_hook.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg_lifecycle_hook.py
@@ -108,6 +108,7 @@ RETURN = '''
 # from ansible.module_utils.basic import *
 # from ansible.module_utils.ec2 import *
 
+import traceback
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import (boto3_conn,
         ec2_argument_spec, get_aws_connection_info)


### PR DESCRIPTION
Without importing `traceback`, there is no proper exception reporting in
case of error. The output of an error on this module would look like
this:

```
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_ulSmOa/ansible_module_ec2_asg_lifecycle_hook.py", line 268, in <module>
    main()
  File "/tmp/ansible_ulSmOa/ansible_module_ec2_asg_lifecycle_hook.py", line 261, in main
    changed = create_lifecycle_hook(connection, module)
  File "/tmp/ansible_ulSmOa/ansible_module_ec2_asg_lifecycle_hook.py", line 175, in create_lifecycle_hook
    module.fail_json(msg="Failed to create LifecycleHook %s" % str(e), exception=traceback.format_exc(e))
NameError: global name 'traceback' is not defined

fatal: [localhost]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_name": "ec2_asg_lifecycle_hook"
    },
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_ulSmOa/ansible_module_ec2_asg_lifecycle_hook.py\", line 268, in <module>\n    main()\n  File \"/tmp/ansible_ulSmOa/ansible_module_ec2_asg_lifecycle_hook.py\", line 261, in main\n    changed = create_lifecycle_hook(connection, module)\n  File \"/tmp/ansible_ulSmOa/ansible_module_ec2_asg_lifecycle_hook.py\", line 175, in create_lifecycle_hook\n    module.fail_json(msg=\"Failed to create LifecycleHook %s\" % str(e), exception=traceback.format_exc(e))\nNameError: global name 'traceback' is not defined\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE"
}

```

Simply importing this lib fixes it.
